### PR TITLE
Add NetworkPolicy controller to restrict operator pod traffic (#110)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -37,3 +37,138 @@ jobs:
       - name: Run E2E tests
         run: |
           make test-e2e-ci
+
+  test-e2e-olm-upgrade:
+    name: Test OLM upgrade
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CONTAINER_TOOL: podman
+      REGISTRY: ghcr.io
+      IMG: ghcr.io/securesign/model-validation-operator:dev-${{ github.sha }}
+      AGENT_IMG: ghcr.io/securesign/model-validation-operator-agent:dev-${{ github.sha }}
+      BUNDLE_IMG: ghcr.io/securesign/model-validation-operator-bundle:dev-${{ github.sha }}
+      CATALOG_IMG: ghcr.io/securesign/model-validation-operator-fbc:dev-${{ github.sha }}
+      OCP_VERSION: ${{ vars.OLM_INDEX_VERSION }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
+
+      - name: Compute OLM upgrade version
+        run: |
+          CURRENT=$(grep '^VERSION ?=' Makefile | cut -d= -f2 | tr -d ' ')
+          NEXT=$(echo "$CURRENT" | awk -F. '{print $1"."$2"."$3+1}')
+          echo "OLM_UPGRADE_VERSION=$NEXT" >> "$GITHUB_ENV"
+
+      - name: Setup Go
+        uses: actions/setup-go@def8c394e3ad351a79bc93815e4a585520fe993b # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Log in to GitHub Container Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          auth_file_path: /tmp/config.json
+
+      - name: Log in to registry.redhat.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: registry.redhat.io
+          auth_file_path: /tmp/config.json
+
+      - name: Log in to brew.registry.redhat.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: brew.registry.redhat.io
+          auth_file_path: /tmp/config.json
+
+      - name: Swap to dev images
+        run: make dev-images
+
+      - name: Build and push operator image
+        run: make docker-build docker-push IMG=${{ env.IMG }} AGENT_IMG=${{ env.AGENT_IMG }}
+
+      - name: Build and push agent image
+        run: make docker-build-agent docker-push-agent AGENT_IMG=${{ env.AGENT_IMG }}
+
+      - name: Build and push bundle
+        run: make bundle bundle-build bundle-push IMG=${{ env.IMG }} BUNDLE_IMG=${{ env.BUNDLE_IMG }} VERSION=${{ env.OLM_UPGRADE_VERSION }} CHANNELS=tech-preview DEFAULT_CHANNEL=tech-preview
+
+      - name: Install OPM
+        run: |
+          make opm
+          echo "$(pwd)/bin" >> $GITHUB_PATH
+
+      - name: Checkout FBC source
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
+        with:
+          repository: securesign/fbc
+          ref: main
+          path: fbc
+
+      - name: Build and push FBC catalog
+        env:
+          BUNDLE_IMAGE: ${{ env.BUNDLE_IMG }}
+          BUNDLE_NAME: model-validation-operator.v${{ env.OLM_UPGRADE_VERSION }}
+          FBC_DIR: model-validation-operator
+          GRAPH: ${{ env.OCP_VERSION }}/model-validation-operator/graph.yaml
+          CHANNELS: tech-preview
+          CATALOG_FILE: ${{ env.OCP_VERSION }}/model-validation-operator/catalog/model-validation-operator/catalog.json
+        run: |
+          cd fbc
+          utils/configure_bundles.sh
+          utils/configure_channels.sh
+          utils/render_catalog.sh
+
+          cat $GRAPH
+          opm validate $OCP_VERSION/model-validation-operator/catalog/model-validation-operator
+          $CONTAINER_TOOL build $OCP_VERSION/model-validation-operator -f catalog.Dockerfile -t $CATALOG_IMG
+          $CONTAINER_TOOL push $CATALOG_IMG
+
+      - name: Create kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
+        with:
+          cluster_name: kind
+          config: ./ci/kind-config.yaml
+
+      - name: Wait for kind cluster to be ready
+        run: |
+          kubectl wait --for=condition=Ready nodes --all --timeout=300s
+          kubectl wait --for=condition=Ready --namespace=kube-system pod --all --timeout=300s
+          echo "Cluster is ready"
+
+      - name: Load images into Kind
+        run: |
+          $CONTAINER_TOOL save ${{ env.IMG }} -o operator-oci.tar
+          $CONTAINER_TOOL save ${{ env.AGENT_IMG }} -o agent-oci.tar
+          $CONTAINER_TOOL save ${{ env.BUNDLE_IMG }} -o bundle-oci.tar
+          $CONTAINER_TOOL save ${{ env.CATALOG_IMG }} -o catalog-oci.tar
+
+          kind load image-archive operator-oci.tar
+          kind load image-archive agent-oci.tar
+          kind load image-archive bundle-oci.tar
+          kind load image-archive catalog-oci.tar
+
+      - name: Install OLM
+        run: make e2e-install-olm
+
+      - name: Setup namespaces
+        run: make e2e-setup-namespaces
+
+      - name: Run OLM upgrade tests
+        env:
+          TEST_BASE_CATALOG: registry.redhat.io/redhat/redhat-operator-index:${{ vars.OLM_INDEX_VERSION }}
+          TEST_TARGET_CATALOG: ${{ env.CATALOG_IMG }}
+        run: |
+          go test ./test/e2e-olm/ -v -ginkgo.v -timeout 20m

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ IMG ?= $(IMAGE_TAG_BASE):v$(VERSION)
 
 # AGENT_IMG defines the image:tag used for the validation agent.
 # This is injected into the operator binary via ldflags at build time.
-AGENT_IMG ?= ghcr.io/sigstore/model-validation-agent:v0.1.0
+AGENT_IMG ?= $(IMAGE_TAG_BASE)-agent:v$(VERSION)
 
 # LDFLAGS to inject the agent image into the operator binary
 LDFLAGS := -X github.com/sigstore/model-validation-operator/internal/constants.ModelValidationAgentImage=$(AGENT_IMG)
@@ -355,7 +355,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	# Fix webhook configuration in CSV
 	@if [ -f bundle/manifests/model-validation-operator.clusterserviceversion.yaml ]; then \
 		sed -i.bak 's/deploymentName: webhook/deploymentName: model-validation-controller-manager/' bundle/manifests/model-validation-operator.clusterserviceversion.yaml && \
-		sed -i.bak2 's/deploymentName: model-validation-controller-manager/deploymentName: model-validation-controller-manager\n    serviceName: model-validation-webhook/' bundle/manifests/model-validation-operator.clusterserviceversion.yaml && \
+		sed -i.bak2 's/deploymentName: model-validation-controller-manager/deploymentName: model-validation-controller-manager\n    containerPort: 9443\n    serviceName: model-validation-webhook/' bundle/manifests/model-validation-operator.clusterserviceversion.yaml && \
 		rm -f bundle/manifests/model-validation-operator.clusterserviceversion.yaml.bak bundle/manifests/model-validation-operator.clusterserviceversion.yaml.bak2; \
 	fi
 	$(OPERATOR_SDK) bundle validate ./bundle
@@ -528,14 +528,15 @@ e2e-build-agent-image:
 e2e-load-images: e2e-build-image e2e-build-agent-image e2e-build-test-model
 	@echo "Pulling model-transparency-cli image..."
 	$(CONTAINER_TOOL) pull $(MODEL_TRANSPARENCY_IMG)
-	@echo "Loading manager image into Kind cluster..."
-	$(KIND) load docker-image -n $(KIND_CLUSTER) $(IMG)
-	@echo "Loading agent image into Kind cluster..."
-	$(KIND) load docker-image -n $(KIND_CLUSTER) $(AGENT_IMG)
-	@echo "Loading model-transparency-cli image into Kind cluster..."
-	$(KIND) load docker-image -n $(KIND_CLUSTER) $(MODEL_TRANSPARENCY_IMG)
-	@echo "Loading test model image into Kind cluster..."
-	$(KIND) load docker-image -n $(KIND_CLUSTER) $(E2E_TEST_MODEL)
+	@echo "Loading images into Kind cluster..."
+	$(CONTAINER_TOOL) save $(IMG) -o /tmp/operator-oci.tar
+	$(CONTAINER_TOOL) save $(AGENT_IMG) -o /tmp/agent-oci.tar
+	$(CONTAINER_TOOL) save $(MODEL_TRANSPARENCY_IMG) -o /tmp/model-transparency-oci.tar
+	$(CONTAINER_TOOL) save $(E2E_TEST_MODEL) -o /tmp/test-model-oci.tar
+	$(KIND) load image-archive /tmp/operator-oci.tar -n $(KIND_CLUSTER)
+	$(KIND) load image-archive /tmp/agent-oci.tar -n $(KIND_CLUSTER)
+	$(KIND) load image-archive /tmp/model-transparency-oci.tar -n $(KIND_CLUSTER)
+	$(KIND) load image-archive /tmp/test-model-oci.tar -n $(KIND_CLUSTER)
 
 # Setup test environment (namespaces, local models on kind cluster, operator)
 
@@ -608,4 +609,35 @@ test-e2e-full: manifests generate fmt vet e2e-setup ## Run e2e tests with setup 
 test-e2e-ci: manifests generate fmt vet e2e-setup ## Run the e2e tests, with setup.  No teardown as the CI workflow will throw away kind
 	@echo "Running e2e tests with infrastructure setup for CI..."
 	go test ./test/e2e/ -v -ginkgo.v
+
+##@ OLM E2E Test Infrastructure
+
+# OLM E2E Variables
+OLM_NAMESPACE ?= $(shell $(KUBECTL) get ns openshift-operator-lifecycle-manager --no-headers >/dev/null 2>&1 && echo openshift-operator-lifecycle-manager || echo olm)
+OLM_CHANNEL ?= tech-preview
+OLM_PACKAGE ?= model-validation-operator
+
+.PHONY: e2e-install-olm
+e2e-install-olm: operator-sdk ## Install OLM on the cluster
+	@echo "Installing OLM..."
+	$(OPERATOR_SDK) olm install --timeout 5m || echo "OLM may already be installed"
+
+.PHONY: e2e-uninstall-olm
+e2e-uninstall-olm: operator-sdk ## Uninstall OLM from the cluster
+	$(OPERATOR_SDK) olm uninstall
+
+.PHONY: e2e-olm-teardown
+e2e-olm-teardown: ## Tear down OLM e2e test environment
+	@echo "Tearing down OLM e2e test environment..."
+	-$(KUBECTL) delete subscription --all -n $(E2E_OPERATOR_NAMESPACE) --timeout=30s
+	-$(KUBECTL) delete csv --all -n $(E2E_OPERATOR_NAMESPACE) --timeout=60s
+	-$(KUBECTL) delete operatorgroup --all -n $(E2E_OPERATOR_NAMESPACE) --timeout=30s
+	-$(KUBECTL) delete catalogsource model-validation-test-catalog -n $(OLM_NAMESPACE) --timeout=30s --ignore-not-found=true
+	-$(KUBECTL) delete pods --all -n $(E2E_TEST_NAMESPACE) --timeout=30s
+	-$(KUBECTL) delete modelvalidations --all -n $(E2E_TEST_NAMESPACE) --timeout=30s
+
+.PHONY: test-e2e-olm
+test-e2e-olm: manifests generate fmt vet ## Run OLM upgrade e2e tests
+	@echo "Running OLM upgrade e2e tests..."
+	go test ./test/e2e-olm/ -v -ginkgo.v -timeout 20m
 

--- a/ci/kind-config.yaml
+++ b/ci/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+    - containerPath: /var/lib/kubelet/config.json
+      hostPath: /tmp/config.json

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sigstore/model-validation-operator/internal/constants"
@@ -30,6 +31,7 @@ import (
 	"github.com/sigstore/model-validation-operator/internal/tracker"
 	"github.com/sigstore/model-validation-operator/internal/utils"
 	"github.com/sigstore/model-validation-operator/internal/webhooks"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -375,9 +377,37 @@ func main() {
 		os.Exit(1)
 	}
 
+	operatorNamespace := getOperatorNamespace()
+	if operatorNamespace == "" {
+		setupLog.Info("operator namespace not found, skipping NetworkPolicy install (set POD_NAMESPACE for local runs)")
+	} else {
+		directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+		if err != nil {
+			setupLog.Error(err, "unable to create client for NetworkPolicy install")
+			os.Exit(1)
+		}
+		if err := controller.InstallNetworkPolicy(context.TODO(), directClient, operatorNamespace); err != nil {
+			setupLog.Error(err, "unable to install NetworkPolicy")
+			os.Exit(1)
+		}
+	}
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+const namespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+func getOperatorNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	data, err := os.ReadFile(namespaceFile)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,11 @@ spec:
           - --health-probe-bind-address=:8081
         image: controller:latest
         name: manager
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,3 +54,12 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - get
+  - patch
+  - update

--- a/internal/controller/networkpolicy.go
+++ b/internal/controller/networkpolicy.go
@@ -1,0 +1,135 @@
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const networkPolicyName = "controller-manager"
+
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;create;update;patch
+
+// InstallNetworkPolicy creates or updates the operator's NetworkPolicy once at startup.
+func InstallNetworkPolicy(ctx context.Context, c client.Client, namespace string) error {
+	logger := log.FromContext(ctx)
+
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyName,
+			Namespace: namespace,
+		},
+	}
+
+	result, err := controllerutil.CreateOrUpdate(ctx, c, np, func() error {
+		np.Labels = map[string]string{
+			"app.kubernetes.io/name":       "model-validation-operator",
+			"app.kubernetes.io/managed-by": "model-validation-operator",
+		}
+		np.Spec = networkPolicySpec()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if result != controllerutil.OperationResultNone {
+		logger.Info("NetworkPolicy installed", "operation", result)
+	}
+
+	return nil
+}
+
+func networkPolicySpec() networkingv1.NetworkPolicySpec {
+	port53 := intstr.FromInt32(53)
+	port443 := intstr.FromInt32(443)
+	port6443 := intstr.FromInt32(6443)
+	port8081 := intstr.FromInt32(8081)
+	port8443 := intstr.FromInt32(8443)
+	port9443 := intstr.FromInt32(9443)
+	protocolTCP := corev1.ProtocolTCP
+	protocolUDP := corev1.ProtocolUDP
+
+	return networkingv1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"control-plane":          "controller-manager",
+				"app.kubernetes.io/name": "model-validation-operator",
+			},
+		},
+		PolicyTypes: []networkingv1.PolicyType{
+			networkingv1.PolicyTypeIngress,
+			networkingv1.PolicyTypeEgress,
+		},
+		Ingress: []networkingv1.NetworkPolicyIngressRule{
+			{
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port9443, Protocol: &protocolTCP},
+				},
+			},
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port8081, Protocol: &protocolTCP},
+				},
+			},
+			{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{},
+					},
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"metrics": "enabled",
+							},
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port8443, Protocol: &protocolTCP},
+				},
+			},
+		},
+		Egress: []networkingv1.NetworkPolicyEgressRule{
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "kube-system",
+							},
+						},
+					},
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "openshift-dns",
+							},
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port53, Protocol: &protocolTCP},
+					{Port: &port53, Protocol: &protocolUDP},
+				},
+			},
+			{
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Port: &port443, Protocol: &protocolTCP},
+					{Port: &port6443, Protocol: &protocolTCP},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/networkpolicy_test.go
+++ b/internal/controller/networkpolicy_test.go
@@ -1,0 +1,146 @@
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	"github.com/sigstore/model-validation-operator/internal/testutil"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("InstallNetworkPolicy", func() {
+	var (
+		ctx       context.Context
+		namespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "test-operator-ns"
+	})
+
+	Context("when the NetworkPolicy does not exist", func() {
+		It("should create the NetworkPolicy with the correct spec", func() {
+			fakeClient := testutil.SetupFakeClientWithObjects()
+
+			err := InstallNetworkPolicy(ctx, fakeClient, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			np := &networkingv1.NetworkPolicy{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(np.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "model-validation-operator"))
+			Expect(np.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "model-validation-operator"))
+
+			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("control-plane", "controller-manager"))
+			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "model-validation-operator"))
+
+			Expect(np.Spec.PolicyTypes).To(ConsistOf(
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			))
+
+			Expect(np.Spec.Ingress).To(HaveLen(3))
+
+			By("webhook ingress restricted by port only (apiserver uses host network)")
+			Expect(np.Spec.Ingress[0].From).To(BeEmpty())
+			expectPort(np.Spec.Ingress[0].Ports, 9443, corev1.ProtocolTCP)
+
+			By("health probe ingress scoped to same-namespace pods")
+			Expect(np.Spec.Ingress[1].From).To(HaveLen(1))
+			Expect(np.Spec.Ingress[1].From[0].PodSelector).NotTo(BeNil())
+			expectPort(np.Spec.Ingress[1].Ports, 8081, corev1.ProtocolTCP)
+
+			By("metrics ingress scoped to same-namespace pods and metrics-enabled namespaces")
+			Expect(np.Spec.Ingress[2].From).To(HaveLen(2))
+			Expect(np.Spec.Ingress[2].From[0].PodSelector).NotTo(BeNil())
+			Expect(np.Spec.Ingress[2].From[1].NamespaceSelector).NotTo(BeNil())
+			Expect(np.Spec.Ingress[2].From[1].NamespaceSelector.MatchLabels).To(HaveKeyWithValue("metrics", "enabled"))
+			expectPort(np.Spec.Ingress[2].Ports, 8443, corev1.ProtocolTCP)
+
+			By("DNS egress scoped to kube-system and openshift-dns")
+			Expect(np.Spec.Egress).To(HaveLen(2))
+			Expect(np.Spec.Egress[0].To).To(HaveLen(2))
+			Expect(np.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels).To(
+				HaveKeyWithValue("kubernetes.io/metadata.name", "kube-system"))
+			Expect(np.Spec.Egress[0].To[1].NamespaceSelector.MatchLabels).To(
+				HaveKeyWithValue("kubernetes.io/metadata.name", "openshift-dns"))
+			expectPort(np.Spec.Egress[0].Ports, 53, corev1.ProtocolTCP)
+			expectPort(np.Spec.Egress[0].Ports, 53, corev1.ProtocolUDP)
+
+			By("API server egress restricted by port only (apiserver uses host network)")
+			Expect(np.Spec.Egress[1].To).To(BeEmpty())
+			expectPort(np.Spec.Egress[1].Ports, 443, corev1.ProtocolTCP)
+			expectPort(np.Spec.Egress[1].Ports, 6443, corev1.ProtocolTCP)
+		})
+	})
+
+	Context("when the NetworkPolicy already exists with wrong spec", func() {
+		It("should update the NetworkPolicy to the desired spec", func() {
+			existingNP := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      networkPolicyName,
+					Namespace: namespace,
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				},
+			}
+
+			fakeClient := testutil.SetupFakeClientWithObjects(existingNP)
+
+			err := InstallNetworkPolicy(ctx, fakeClient, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			np := &networkingv1.NetworkPolicy{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(np.Spec.PolicyTypes).To(ConsistOf(
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			))
+			Expect(np.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("control-plane", "controller-manager"))
+			Expect(np.Spec.Ingress).To(HaveLen(3))
+			Expect(np.Spec.Egress).To(HaveLen(2))
+		})
+	})
+
+	Context("when the NetworkPolicy already has the correct spec", func() {
+		It("should be idempotent and not error", func() {
+			fakeClient := testutil.SetupFakeClientWithObjects()
+
+			err := InstallNetworkPolicy(ctx, fakeClient, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = InstallNetworkPolicy(ctx, fakeClient, namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			np := &networkingv1.NetworkPolicy{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: namespace}, np)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(np.Spec.Ingress).To(HaveLen(3))
+			Expect(np.Spec.Egress).To(HaveLen(2))
+		})
+	})
+})
+
+func expectPort(ports []networkingv1.NetworkPolicyPort, portNum int32, protocol corev1.Protocol) {
+	port := intstr.FromInt32(portNum)
+	found := false
+	for _, p := range ports {
+		if p.Port != nil && *p.Port == port && p.Protocol != nil && *p.Protocol == protocol {
+			found = true
+			break
+		}
+	}
+	ExpectWithOffset(1, found).To(BeTrue(), "expected port %d/%s in ports %v", portNum, protocol, ports)
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sigstore/model-validation-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -185,6 +186,9 @@ func CreateTestNamespacedName(name, namespace string) types.NamespacedName {
 func SetupFakeClientWithObjects(objects ...client.Object) client.Client {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
+		panic(err) // This should not happen in tests
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
 		panic(err) // This should not happen in tests
 	}
 	if err := v1alpha1.AddToScheme(scheme); err != nil {

--- a/test/e2e-olm/olm_upgrade_suite_test.go
+++ b/test/e2e-olm/olm_upgrade_suite_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2eolm
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	utils "github.com/sigstore/model-validation-operator/test/utils"
+)
+
+const (
+	operatorNamespace    = "model-validation-operator-system"
+	webhookTestNamespace = "e2e-webhook-test-ns"
+)
+
+var olmNamespace string
+
+func detectOLMNamespace() string {
+	if utils.KubectlResourceExists("ns", "openshift-operator-lifecycle-manager", "") {
+		return "openshift-operator-lifecycle-manager"
+	}
+	return "olm"
+}
+
+func TestOLMUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting OLM upgrade test suite\n")
+
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(5 * time.Second)
+
+	RunSpecs(t, "OLM Upgrade Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("detecting OLM namespace")
+	olmNamespace = detectOLMNamespace()
+	_, _ = fmt.Fprintf(GinkgoWriter, "Using OLM namespace: %s\n", olmNamespace)
+
+	By("verifying OLM is installed")
+	Expect(utils.KubectlResourceExists("ns", olmNamespace, "")).To(BeTrue(),
+		"OLM namespace should exist - run 'make e2e-install-olm' first")
+
+	By("verifying OLM operators are running")
+	Eventually(func() error {
+		output, err := utils.KubectlGet("pods", "", olmNamespace,
+			"jsonpath={range .items[*]}{.status.phase}{\"\\n\"}{end}")
+		if err != nil {
+			return err
+		}
+		phases := utils.GetNonEmptyLines(output)
+		if len(phases) == 0 {
+			return fmt.Errorf("no OLM pods found in %s namespace", olmNamespace)
+		}
+		for _, phase := range phases {
+			if phase != "Running" && phase != "Succeeded" {
+				return fmt.Errorf("OLM pod not ready, phase: %s", phase)
+			}
+		}
+		return nil
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "OLM operators should be running")
+
+	By("verifying operator namespace exists")
+	Expect(utils.KubectlResourceExists("ns", operatorNamespace, "")).To(BeTrue(),
+		"Operator namespace should exist - run 'make e2e-setup-namespaces' first")
+
+	By("verifying test namespace exists")
+	Expect(utils.KubectlResourceExists("ns", webhookTestNamespace, "")).To(BeTrue(),
+		"Test namespace should exist - run 'make e2e-setup-namespaces' first")
+})
+
+var _ = AfterSuite(func() {
+	_, _ = fmt.Fprintf(GinkgoWriter, "OLM upgrade test suite cleanup complete\n")
+})
+
+var _ = JustAfterEach(func() {
+	if !CurrentSpecReport().Failed() {
+		return
+	}
+
+	_, _ = fmt.Fprintf(GinkgoWriter, "----------------------- Dumping operator resources -----------------------\n")
+	if csvOutput, err := utils.KubectlGet("csv", "", operatorNamespace, "wide"); err == nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "CSVs: %s\n", csvOutput)
+	}
+	if podOutput, err := utils.KubectlGet("pods", "", operatorNamespace, "wide"); err == nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Pods: %s\n", podOutput)
+	}
+})

--- a/test/e2e-olm/olm_upgrade_test.go
+++ b/test/e2e-olm/olm_upgrade_test.go
@@ -192,6 +192,18 @@ var _ = Describe("OLM Upgrade", Ordered, func() {
 	})
 
 	It("should upgrade when the catalog is updated", func() {
+		By("capturing the pre-upgrade controller image")
+		var preUpgradeImage string
+		Eventually(func(g Gomega) {
+			img, err := utils.KubectlGet("deployment", "model-validation-controller-manager",
+				operatorNamespace,
+				"jsonpath={.spec.template.spec.containers[?(@.name==\"manager\")].image}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(img).NotTo(BeEmpty())
+			preUpgradeImage = img
+		}, 1*time.Minute, 5*time.Second).Should(Succeed())
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Pre-upgrade image: %s\n", preUpgradeImage)
+
 		By(fmt.Sprintf("patching CatalogSource to use target catalog: %s", targetCatalogImage))
 		err := utils.KubectlPatch("catalogsource", catalogName, olmNamespace, "merge",
 			fmt.Sprintf(`{"spec":{"image":"%s"}}`, targetCatalogImage))
@@ -237,6 +249,18 @@ var _ = Describe("OLM Upgrade", Ordered, func() {
 				operatorNamespace, "condition=Available", "30s")
 		}, 3*time.Minute, 10*time.Second).Should(Succeed(),
 			"Controller deployment should be available after upgrade")
+
+		By("verifying the controller image changed after upgrade")
+		Eventually(func(g Gomega) {
+			img, err := utils.KubectlGet("deployment", "model-validation-controller-manager",
+				operatorNamespace,
+				"jsonpath={.spec.template.spec.containers[?(@.name==\"manager\")].image}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(img).NotTo(BeEmpty())
+			g.Expect(img).NotTo(Equal(preUpgradeImage),
+				"Controller image should change after upgrade")
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"Controller deployment image should be updated")
 	})
 
 	It("should maintain functionality after upgrade", func() {
@@ -272,6 +296,17 @@ var _ = Describe("OLM Upgrade", Ordered, func() {
 				Equal(constants.ModelValidationInitContainerName))
 		}, 1*time.Minute, 5*time.Second).Should(Succeed(),
 			"Init container should be injected after upgrade")
+	})
+
+	It("should allow CR deletion after upgrade", func() {
+		By("deleting the ModelValidation CR")
+		cleanupResource("modelvalidation", testModelName, webhookTestNamespace)
+
+		By("verifying the ModelValidation CR is deleted")
+		Eventually(func() bool {
+			return utils.KubectlResourceExists("modelvalidation", testModelName, webhookTestNamespace)
+		}, 1*time.Minute, 5*time.Second).Should(BeFalse(),
+			"ModelValidation CR should be deleted after upgrade")
 	})
 
 })

--- a/test/e2e-olm/olm_upgrade_test.go
+++ b/test/e2e-olm/olm_upgrade_test.go
@@ -1,0 +1,277 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2eolm
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/sigstore/model-validation-operator/internal/constants"
+	utils "github.com/sigstore/model-validation-operator/test/utils"
+)
+
+func cleanupResource(resource, name, namespace string) {
+	args := []string{"delete", resource}
+	if name != "" {
+		args = append(args, name)
+	} else {
+		args = append(args, "--all")
+	}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	args = append(args, "--timeout=60s", "--ignore-not-found=true")
+	_, _ = utils.Run(exec.Command("kubectl", args...))
+}
+
+func envOrDefault(key, defaultValue string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultValue
+}
+
+var _ = Describe("OLM Upgrade", Ordered, func() {
+	var (
+		baseCatalogImage   string
+		targetCatalogImage string
+		channelName        string
+		packageName        string
+		baseCSV            string
+	)
+
+	const (
+		catalogName       = "model-validation-test-catalog"
+		operatorGroupName = "model-validation-og"
+		subscriptionName  = "model-validation-operator"
+		testModelName     = "olm-upgrade-test-model"
+	)
+
+	BeforeAll(func() {
+		baseCatalogImage = os.Getenv("TEST_BASE_CATALOG")
+		Expect(baseCatalogImage).NotTo(BeEmpty(), "TEST_BASE_CATALOG env var must be set")
+
+		targetCatalogImage = os.Getenv("TEST_TARGET_CATALOG")
+		Expect(targetCatalogImage).NotTo(BeEmpty(), "TEST_TARGET_CATALOG env var must be set")
+
+		channelName = envOrDefault("OLM_CHANNEL", "tech-preview")
+		packageName = envOrDefault("OLM_PACKAGE", "model-validation-operator")
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "OLM Upgrade Test Configuration:\n")
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Base catalog: %s\n", baseCatalogImage)
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Target catalog: %s\n", targetCatalogImage)
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Channel: %s\n", channelName)
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Package: %s\n", packageName)
+
+		DeferCleanup(func() {
+			By("cleaning up OLM test resources")
+			cleanupResource("pods", "", webhookTestNamespace)
+			cleanupResource("modelvalidations", "", webhookTestNamespace)
+			cleanupResource("subscription", subscriptionName, operatorNamespace)
+			cleanupResource("csv", "", operatorNamespace)
+			cleanupResource("operatorgroup", operatorGroupName, operatorNamespace)
+			cleanupResource("catalogsource", catalogName, olmNamespace)
+		})
+	})
+
+	It("should install the initial version via OLM", func() {
+		By("creating a CatalogSource with the base catalog image")
+		err := utils.KubectlApply(catalogSourceTemplate, utils.CatalogSourceTemplateData{
+			Name:      catalogName,
+			Namespace: olmNamespace,
+			Image:     baseCatalogImage,
+		})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create CatalogSource")
+
+		By("waiting for CatalogSource to be ready")
+		Eventually(func(g Gomega) {
+			status, err := utils.KubectlGet("catalogsource", catalogName, olmNamespace,
+				"jsonpath={.status.connectionState.lastObservedState}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(status).To(Equal("READY"))
+		}, 5*time.Minute, 5*time.Second).Should(Succeed(), "CatalogSource should become READY")
+
+		By("creating an OperatorGroup for AllNamespaces mode")
+		err = utils.KubectlApply(operatorGroupTemplate, utils.OperatorGroupTemplateData{
+			Name:      operatorGroupName,
+			Namespace: operatorNamespace,
+		})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create OperatorGroup")
+
+		By("creating a Subscription to trigger installation")
+		err = utils.KubectlApply(subscriptionTemplate, utils.SubscriptionTemplateData{
+			Name:                   subscriptionName,
+			Namespace:              operatorNamespace,
+			Channel:                channelName,
+			PackageName:            packageName,
+			CatalogSourceName:      catalogName,
+			CatalogSourceNamespace: olmNamespace,
+		})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create Subscription")
+
+		By("waiting for subscription to report an installed CSV")
+		Eventually(func(g Gomega) {
+			csv, err := utils.KubectlGet("subscription", subscriptionName, operatorNamespace,
+				"jsonpath={.status.installedCSV}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(csv).NotTo(BeEmpty())
+			baseCSV = csv
+		}, 5*time.Minute, 5*time.Second).Should(Succeed(),
+			"Subscription should report an installed CSV")
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Installed base CSV: %s\n", baseCSV)
+
+		By(fmt.Sprintf("waiting for base CSV %s to reach Succeeded phase", baseCSV))
+		Eventually(func(g Gomega) {
+			phase, err := utils.KubectlGet("csv", baseCSV, operatorNamespace,
+				"jsonpath={.status.phase}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(phase).To(Equal("Succeeded"))
+		}, 5*time.Minute, 5*time.Second).Should(Succeed(),
+			"Base CSV should reach Succeeded phase")
+
+		By("waiting for controller deployment to be available")
+		Eventually(func() error {
+			return utils.KubectlWait("deployment", "model-validation-controller-manager",
+				operatorNamespace, "condition=Available", "30s")
+		}, 3*time.Minute, 10*time.Second).Should(Succeed(),
+			"Controller deployment should be available")
+
+		By("verifying controller pod is running")
+		Eventually(func(g Gomega) {
+			output, err := utils.KubectlGet("pods", "", operatorNamespace,
+				"jsonpath={.items[?(@.metadata.labels.control-plane==\"controller-manager\")].status.phase}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("Running"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"Controller pod should be running")
+	})
+
+	It("should have a functioning webhook after OLM installation", func() {
+		By("deploying a ModelValidation CR")
+		err := utils.KubectlApply(modelValidationTemplate, utils.CRTemplateData{
+			ModelName: testModelName,
+			Namespace: webhookTestNamespace,
+		})
+		Expect(err).NotTo(HaveOccurred(), "Failed to apply ModelValidation CR")
+
+		By("deploying a test pod with model validation label")
+		err = utils.KubectlApply(podTemplate, utils.DefaultPodData(
+			"olm-test-pod-initial", webhookTestNamespace, testModelName, "olm-upgrade"))
+		Expect(err).NotTo(HaveOccurred(), "Failed to deploy test pod")
+
+		By("verifying the init container is injected by the webhook")
+		Eventually(func(g Gomega) {
+			var pod corev1.Pod
+			err := utils.KubectlGetJSON("pod", "olm-test-pod-initial", webhookTestNamespace, &pod)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pod.Spec.InitContainers).ToNot(BeEmpty(),
+				"Pod should have init containers after webhook injection")
+			g.Expect(pod.Spec.InitContainers[0].Name).To(
+				Equal(constants.ModelValidationInitContainerName))
+		}, 1*time.Minute, 5*time.Second).Should(Succeed(),
+			"Init container should be injected")
+	})
+
+	It("should upgrade when the catalog is updated", func() {
+		By(fmt.Sprintf("patching CatalogSource to use target catalog: %s", targetCatalogImage))
+		err := utils.KubectlPatch("catalogsource", catalogName, olmNamespace, "merge",
+			fmt.Sprintf(`{"spec":{"image":"%s"}}`, targetCatalogImage))
+		Expect(err).NotTo(HaveOccurred(), "Failed to patch CatalogSource")
+
+		By("waiting for CatalogSource to reconnect with updated catalog")
+		Eventually(func(g Gomega) {
+			status, err := utils.KubectlGet("catalogsource", catalogName, olmNamespace,
+				"jsonpath={.status.connectionState.lastObservedState}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(status).To(Equal("READY"))
+		}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+			"CatalogSource should reconnect after update")
+
+		By("waiting for subscription to report a new installed CSV")
+		Eventually(func(g Gomega) {
+			csv, err := utils.KubectlGet("subscription", subscriptionName, operatorNamespace,
+				"jsonpath={.status.installedCSV}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(csv).NotTo(BeEmpty())
+			g.Expect(csv).NotTo(Equal(baseCSV), "installed CSV should change after upgrade")
+		}, 5*time.Minute, 10*time.Second).Should(Succeed(),
+			"Subscription should report a new installed CSV after upgrade")
+
+		var upgradeCSV string
+		upgradeCSV, err = utils.KubectlGet("subscription", subscriptionName, operatorNamespace,
+			"jsonpath={.status.installedCSV}")
+		Expect(err).NotTo(HaveOccurred())
+		_, _ = fmt.Fprintf(GinkgoWriter, "  Upgraded CSV: %s (was: %s)\n", upgradeCSV, baseCSV)
+
+		By(fmt.Sprintf("waiting for upgrade CSV %s to reach Succeeded phase", upgradeCSV))
+		Eventually(func(g Gomega) {
+			phase, err := utils.KubectlGet("csv", upgradeCSV, operatorNamespace,
+				"jsonpath={.status.phase}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(phase).To(Equal("Succeeded"))
+		}, 5*time.Minute, 10*time.Second).Should(Succeed(),
+			"Upgrade CSV should reach Succeeded phase")
+
+		By("waiting for controller deployment to be available after upgrade")
+		Eventually(func() error {
+			return utils.KubectlWait("deployment", "model-validation-controller-manager",
+				operatorNamespace, "condition=Available", "30s")
+		}, 3*time.Minute, 10*time.Second).Should(Succeed(),
+			"Controller deployment should be available after upgrade")
+	})
+
+	It("should maintain functionality after upgrade", func() {
+		By("verifying existing ModelValidation CR survived the upgrade")
+		Expect(utils.KubectlResourceExists("modelvalidation", testModelName,
+			webhookTestNamespace)).To(BeTrue(),
+			"Existing ModelValidation CR should persist through upgrade")
+
+		By("verifying controller pod is running after upgrade")
+		Eventually(func(g Gomega) {
+			output, err := utils.KubectlGet("pods", "", operatorNamespace,
+				"jsonpath={.items[?(@.metadata.labels.control-plane==\"controller-manager\")].status.phase}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("Running"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"Controller pod should be running after upgrade")
+
+		By("deploying a new test pod to verify webhook still works after upgrade")
+		Eventually(func() error {
+			return utils.KubectlApply(podTemplate, utils.DefaultPodData(
+				"olm-test-pod-upgrade", webhookTestNamespace, testModelName, "olm-upgrade"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+			"Post-upgrade test pod should be accepted by webhook")
+
+		By("verifying the init container is injected on the new pod")
+		Eventually(func(g Gomega) {
+			var pod corev1.Pod
+			err := utils.KubectlGetJSON("pod", "olm-test-pod-upgrade", webhookTestNamespace, &pod)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pod.Spec.InitContainers).ToNot(BeEmpty(),
+				"Post-upgrade pod should have init containers")
+			g.Expect(pod.Spec.InitContainers[0].Name).To(
+				Equal(constants.ModelValidationInitContainerName))
+		}, 1*time.Minute, 5*time.Second).Should(Succeed(),
+			"Init container should be injected after upgrade")
+	})
+
+})

--- a/test/e2e-olm/testdata.go
+++ b/test/e2e-olm/testdata.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2eolm contains e2e tests for OLM upgrade lifecycle.
+package e2eolm
+
+import _ "embed"
+
+// OLM resource templates
+
+//go:embed testdata/catalogsource_template.yaml
+var catalogSourceTemplate []byte
+
+//go:embed testdata/operatorgroup_template.yaml
+var operatorGroupTemplate []byte
+
+//go:embed testdata/subscription_template.yaml
+var subscriptionTemplate []byte
+
+// Shared resource templates (copied from test/e2e/testdata)
+
+//go:embed testdata/modelvalidation_template.yaml
+var modelValidationTemplate []byte
+
+//go:embed testdata/pod_template.yaml
+var podTemplate []byte

--- a/test/e2e-olm/testdata/catalogsource_template.yaml
+++ b/test/e2e-olm/testdata/catalogsource_template.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  sourceType: grpc
+  image: {{.Image}}
+  displayName: Model Validation Operator Test Catalog
+  publisher: E2E Tests
+  updateStrategy:
+    registryPoll:
+      interval: 15m

--- a/test/e2e-olm/testdata/modelvalidation_template.yaml
+++ b/test/e2e-olm/testdata/modelvalidation_template.yaml
@@ -1,0 +1,13 @@
+apiVersion: ml.sigstore.dev/v1alpha1
+kind: ModelValidation
+metadata:
+  name: {{.ModelName}}
+  namespace: {{.Namespace}}
+spec:
+  config:
+    publicKeyConfig:
+      keyPath: {{if .KeyPath}}{{.KeyPath}}{{else}}/keys/test_public_key.pub{{end}}
+  model:
+    path: /data
+    signaturePath: /data/model.sig
+  imagePullPolicy: IfNotPresent

--- a/test/e2e-olm/testdata/operatorgroup_template.yaml
+++ b/test/e2e-olm/testdata/operatorgroup_template.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec: {}

--- a/test/e2e-olm/testdata/pod_template.yaml
+++ b/test/e2e-olm/testdata/pod_template.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{.PodName}}
+  namespace: {{.Namespace}}
+  labels:
+    validation.ml.sigstore.dev/ml: "{{.ModelName}}"{{if .TestBatch}}
+    test-batch: "{{.TestBatch}}"{{end}}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: test-container
+    image: busybox:latest
+    command: ["sh", "-c", "sleep 3600"]{{if .VolumeMounts}}
+    volumeMounts:{{range .VolumeMounts}}
+    - name: {{.Name}}
+      mountPath: {{.MountPath}}
+      readOnly: {{.ReadOnly}}{{end}}{{end}}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 1000
+      seccompProfile:
+        type: RuntimeDefault{{if .Volumes}}
+  volumes:{{range .Volumes}}
+  - name: {{.Name}}{{if .HostPath}}
+    hostPath:
+      path: {{.HostPath.Path}}
+      type: {{if .HostPath.Type}}{{.HostPath.Type}}{{else}}Directory{{end}}{{end}}{{end}}{{end}}

--- a/test/e2e-olm/testdata/subscription_template.yaml
+++ b/test/e2e-olm/testdata/subscription_template.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  channel: {{.Channel}}
+  name: {{.PackageName}}
+  source: {{.CatalogSourceName}}
+  sourceNamespace: {{.CatalogSourceNamespace}}
+  installPlanApproval: Automatic

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -95,6 +95,29 @@ type ClusterRoleBindingTemplateData struct {
 	ClusterRoleName    string
 }
 
+// CatalogSourceTemplateData represents template data for OLM CatalogSource
+type CatalogSourceTemplateData struct {
+	Name      string
+	Namespace string
+	Image     string
+}
+
+// OperatorGroupTemplateData represents template data for OLM OperatorGroup
+type OperatorGroupTemplateData struct {
+	Name      string
+	Namespace string
+}
+
+// SubscriptionTemplateData represents template data for OLM Subscription
+type SubscriptionTemplateData struct {
+	Name                   string
+	Namespace              string
+	Channel                string
+	PackageName            string
+	CatalogSourceName      string
+	CatalogSourceNamespace string
+}
+
 // Run executes the provided command within this context
 func Run(cmd *exec.Cmd) (string, error) {
 	dir, _ := GetProjectDir()
@@ -136,7 +159,9 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.ReplaceAll(wd, "/test/e2e", "")
+	if idx := strings.LastIndex(wd, "/test/"); idx != -1 {
+		wd = wd[:idx]
+	}
 	return wd, nil
 }
 
@@ -316,6 +341,19 @@ func GetMetricsOutput(namespace, podName string) string {
 		return ""
 	}
 	return output
+}
+
+// KubectlPatch patches a Kubernetes resource
+func KubectlPatch(resource, name, namespace, patchType, patch string) error {
+	args := []string{"patch", resource, name}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	args = append(args, "--type", patchType, "-p", patch)
+
+	cmd := exec.Command("kubectl", args...)
+	_, err := Run(cmd)
+	return err
 }
 
 // KubectlDescribe describes a Kubernetes resource


### PR DESCRIPTION
* Add NetworkPolicy controller to restrict operator pod traffic

Introduce a self-healing NetworkPolicy reconciler that enforces ingress (9443, 8081) and egress (DNS, HTTPS, K8s API) rules on the operator pod. The controller watches for drift and recreates or updates the policy automatically. Includes RBAC permissions, POD_NAMESPACE downward API injection, unit tests, and test utility updates for NetworkPolicy scheme.

* Add peer selectors and metrics port to NetworkPolicy



Add OLM upgrade version logic instead of manually hardcoding

* Allow same-namespace pods to reach metrics port in NetworkPolicy



* Drop namespace selectors for apiserver NetworkPolicy rules



* Replace NetworkPolicy reconciler with one-shot startup install

Instead of a dedicated controller that watches and reconciles the NetworkPolicy, install it once at operator startup using a direct client call. This simplifies the codebase while achieving the same result — the operator's NetworkPolicy is created or updated before the manager starts.



---------

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
